### PR TITLE
Skip record on error

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -14,7 +14,11 @@ if (! targetCalendar ) {
 function main() {
   const contacts = getContactsWithBirthdays();
   for (contact of contacts) {
-    updateOrCreateBirthDayEvent(contact);
+    try {
+      updateOrCreateBirthDayEvent(contact);
+    } catch (e) {
+      Logger.log(`❌ Error processing contact "${contact?.getFullName()||'unknown'}": ${e}`);
+    }
   }
 
   Logger.log (`Processed ${contacts.length} contacts with birthday`);


### PR DESCRIPTION
When an error occurs when processing a contact, generate a log entry and move on to the next contact.